### PR TITLE
passing files as argument when creating interface library is a new feature in cmake 3.19

### DIFF
--- a/third_party/microprofile/CMakeLists.txt
+++ b/third_party/microprofile/CMakeLists.txt
@@ -1,7 +1,4 @@
-add_library(microprofile INTERFACE
-        microprofile.h
-        microprofiledraw.h
-        microprofileui.h)
+add_library(microprofile INTERFACE)
 
 target_include_directories(microprofile INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 


### PR DESCRIPTION
microprofiler的cmake文件：
把文件当参数传到`add_library(<name> INTERFACE)`里好像是cmake 3.19才出的，cmake版本比较低的同学可能会出问题。
应该只用target include就够了